### PR TITLE
Add package auto discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,5 @@
                 "MargaTampu\\LaravelTeamsLogging\\LoggerServiceProvider"
             ]
         }
-    },
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,12 @@
         "psr-4": {
             "MargaTampu\\LaravelTeamsLogging\\": "src/"
         }
-    }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "MargaTampu\\LaravelTeamsLogging\\LoggerServiceProvider"
+            ]
+        }
+    },
 }


### PR DESCRIPTION
This removes the need for regular Laravel users to manually register the service provider in the `config/app.php` file.