### PR TITLE
Readme : fix syntax for additional info in cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,8 @@ Or you can include additional info to card message using log context.
 
 ```php
 Log::channel('teams')->error('Error message', [
-    [
-        'name'  => 'Assigned to',
-        'value' => 'Unassigned',
-    ]
+    'name'  => 'value',
+    'Assigned to' => 'Unassigned'
 ]);
 ```
 


### PR DESCRIPTION
We need to send the context as simple array with key => value data : 
```
$facts = [];
foreach($record['context'] as $name => $value){
    $facts[] = ['name' => $name, 'value' => $value];
}
```