### PR TITLE
Changed php and monolog versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
 		}
 	],
 	"require": {
-		"php": ">=7.0",
-		"monolog/monolog": "^1.23|^2.0|^3.0"
+		"php": "^8.1",
+		"monolog/monolog": "^3.0"
 	},
 	"require-dev": {
 		"ext-curl": "*"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "easyweb/laravel-teams-logging",
+	"name": "margatampu/laravel-teams-logging",
 	"description": "Laravel handler to sending messages to Microsoft Teams using the Incoming Webhook connector",
 	"license": "MIT",
 	"authors": [


### PR DESCRIPTION
\Monolog\LogRecord used in LoggerHandler has only been introduced in Monolog 3 so older versions are not supported.