### PR TITLE
"Sent Date" optional in card style logging

### DIFF
--- a/src/LoggerHandler.php
+++ b/src/LoggerHandler.php
@@ -49,10 +49,12 @@ class LoggerHandler extends AbstractProcessingHandler
             }
 
             // Date
-            $facts[] = [
-                'name'  => 'Sent Date',
-                'value' => date('D, M d Y H:i:s e'),
-            ];
+            if (config('teams.show_date', true)) {
+                $facts[] = [
+                    'name' => 'Sent Date',
+                    'value' => date(config('teams.date_format', 'D, M d Y H:i:s e')),
+                ];
+            }
 
             // Route
             if (config('teams.show_route', false) && request()) {
@@ -101,8 +103,8 @@ class LoggerHandler extends AbstractProcessingHandler
 
         // LoggerMessage $data['sections']
         $section = [
-            'activityTitle'    => config('teams.verbose_title', false) 
-                ? strtoupper($level) . ' : ' . $this->name . ' (' . config('app.url') . ')' 
+            'activityTitle'    => config('teams.verbose_title', false)
+                ? strtoupper($level) . ' : ' . $this->name . ' (' . config('app.url') . ')'
                 : $this->name,
             'activitySubtitle' => $message,
             'facts'            => $facts,

--- a/src/config/teams.php
+++ b/src/config/teams.php
@@ -24,14 +24,34 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Display Route 
+    | Display Date
+    |--------------------------------------------------------------------------
+    |
+    | Display the date of the logged notification. Allowed value: false (default) and true
+    |
+    */
+    'show_date' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Display Date Format
+    |--------------------------------------------------------------------------
+    |
+    | The format of the date of the logged notification. Allowed value: Any format accepted by
+    | DateTimeInterface::format() (). Default: 'D, M d Y H:i:s e'
+    |
+    */
+    'date_format' => 'D, M d Y H:i:s e',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Display Route
     |--------------------------------------------------------------------------
     |
     | Display route (if available) called which led to the logged notification. Allowed value: false (default) and true
     |
     */
     'show_route' => false,
-
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
I've added a config value to enable/disable the "Sent Date" line in the card style message.
Imho showing the date in the message is a little redundant because the Teams message already has a timestamp

I also added a config value to specify the format of the date

All changes are non-intrusive, which means users won't notice anything when upgrading.
I did however set the "sent date" disabled by default, but this will only affect new installations.