### PR TITLE
Fix: Duplicate context in card style message

### DIFF
--- a/src/LoggerHandler.php
+++ b/src/LoggerHandler.php
@@ -40,13 +40,7 @@ class LoggerHandler extends AbstractProcessingHandler
     protected function getMessage(LogRecord $record)
     {
         if ($this->style == 'card') {
-            // Include context as facts to send to microsoft teams
-
             $facts = [];
-
-            foreach($record['context'] as $name => $value){
-                $facts[] = ['name' => $name, 'value' => (string) $value];
-            }
 
             // Date
             $facts[] = [


### PR DESCRIPTION
The context is shown twice in the card style message.
This pull request is a fix for it.